### PR TITLE
Fixed the index of the itinerary accommodation and destinations when …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Dev - Separated the 'departs_from' and 'ends_in' fields into their own function.
 * Dev - Moving the API info tooltip to a better position.
 * Fix - Fixed an error in the set_country function prohibiting certain tours from completing.
+* Fix - Fixed the index of the itinerary accommodation and destinations when using a mobile safari.
 
 ### 1.3.1 - 2 October 2019
 * Dev - Adding extra instructions on the importer.

--- a/classes/class-lsx-wetu-importer-tours.php
+++ b/classes/class-lsx-wetu-importer-tours.php
@@ -836,11 +836,11 @@ class LSX_WETU_Importer_Tours extends LSX_WETU_Importer {
 	 */
 	public function get_mobile_destination( $day, $leg, $id ) {
 		$current_destination = false;
-		$current_day = (int) $day['itinerary_start_day'] + 1;
+		$current_day = (int) $day['period_start_day'];
 		if ( isset( $leg['stops'] ) ) {
 			foreach ( $leg['stops'] as $stop ) {
-				$arrival_day = (int) $stop['arrival_day'] + 1;
-				$departure_day = (int) $stop['departure_day'] + 1;
+				$arrival_day = (int) $stop['arrival_day'];
+				$departure_day = (int) $stop['departure_day'];
 				if ( $arrival_day <= $current_day && $current_day < $departure_day ) {
 					$current_destination = $this->set_destination( $stop, $id, 0 );
 				}
@@ -858,11 +858,11 @@ class LSX_WETU_Importer_Tours extends LSX_WETU_Importer {
 	 */
 	public function get_mobile_accommodation( $day, $leg, $id ) {
 		$current_accommodation = false;
-		$current_day = (int) $day['itinerary_start_day'] + 1;
+		$current_day = (int) $day['period_start_day'];
 		if ( isset( $leg['stops'] ) ) {
 			foreach ( $leg['stops'] as $stop ) {
-				$arrival_day = (int) $stop['arrival_day'] + 1;
-				$departure_day = (int) $stop['departure_day'] + 1;
+				$arrival_day = (int) $stop['arrival_day'];
+				$departure_day = (int) $stop['departure_day'];
 				if ( $arrival_day <= $current_day && $current_day < $departure_day ) {
 					$current_accommodation = $this->set_accommodation( $stop, $id, 0 );
 				}


### PR DESCRIPTION
When importing a tour with mobile safaris, the destination and accommodation would be set incorrectly.

**Changes**
We have set the accommodation and destination loop 1 index back when the "period" being cycled through is a "Mobile" period.