### PR TITLE
Add/image automation

### DIFF
--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -34,6 +34,7 @@ class Cron {
 	 */
 	public function __construct() {
 		add_action( 'lsx_wetu_importer_settings_before', array( $this, 'watch_for_trigger' ), 200 );
+		add_action( 'lsx_wetu_accommodation_images_cron', array( $this, 'process' ), 10, 1 );
 	}
 
 	/**
@@ -75,7 +76,8 @@ class Cron {
 
 			// If activate and its not running.
 			if ( false === $schedule && 'activate' === $accommodation_cron ) {
-				$this->schedule();
+				$schedule = 'daily';
+				$this->schedule( 'lsx_wetu_accommodation_images_cron', $schedule );
 			} elseif ( true === $schedule && 'deactivate' === $accommodation_cron ) {
 				$this->deactivate();
 			}
@@ -95,13 +97,15 @@ class Cron {
 	 * This function will schedule the cron event.
 	 *
 	 * @param string $task
+	 * @param string $schedule
+	 * @param string $time
 	 * @return void
 	 */
-	public function schedule( $task = 'lsx_wetu_accommodation_images_cron' ) {
-		add_action( $task, array( $this, 'process' ) );
-		add_action( $task, 'lsx_wetu_accommodation_images_callback' );
-		add_action( 'lsx_wetu_accommodation_images_cron', 'lsx_wetu_accommodation_images_callback' );
-		wp_schedule_event( time(), 'daily', 'lsx_wetu_accommodation_images_cron' );
+	public function schedule( $task = 'lsx_wetu_accommodation_images_cron', $schedule = 'daily', $time = '' ) {
+		if ( '' === $time ) {
+			$time = time();
+		}
+		wp_schedule_event( $time, $schedule, $task, array( $task ) );
 	}
 
 	/**
@@ -109,12 +113,31 @@ class Cron {
 	 *
 	 * @return void
 	 */
-	public function process() {
-		// do your stuff.
+	public function process( $task = '' ) {
+		switch ( $task ) {
+			case 'lsx_wetu_accommodation_images_cron':
+
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * This is the function that will be triggered by the cron event.
+	 *
+	 * @return void
+	 */
+	public function sync_accommodation_images() {
+		switch ( $task ) {
+			case 'lsx_wetu_accommodation_images_cron':
+				
+				break;
+
+			default:
+				break;
+		}
 	}
 }
 Cron::get_instance();
-
-function lsx_wetu_accommodation_images_callback() {
-
-}

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -106,7 +106,7 @@ class Cron {
 	 * @return void
 	 */
 	public function deactivate( $task = 'lsx_wetu_accommodation_images_cron' ) {
-		wp_clear_scheduled_hook( $task );
+		wp_clear_scheduled_hook( $task, array( $task ) );
 	}
 
 	/**
@@ -165,15 +165,18 @@ class Cron {
 			$output    = array_slice( $has_accommodation, 0, 4 );   // returns "a", "b", and "c"
 
 			// Run through the current items.
+			update_option( 'lsx_wetu_nexttime', $next_time );
 
 			// Save the values for next time.
 			if ( ! empty( $next_time ) ) {
 				update_option( $task, $next_time );
 			} else {
+				delete_option( $task );
 				$this->deactivate( $task );
 			}
 		} else {
 			$this->deactivate( $task );
+			update_option( 'lsx_wetu_nexttime', $task );
 		}
 	}
 

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -36,7 +36,7 @@ class Cron {
 		add_filter( 'cron_schedules', array( $this, 'register_schedule' ), 10, 1 );
 		add_action( 'lsx_wetu_importer_settings_before', array( $this, 'watch_for_trigger' ), 200 );
 		add_action( 'lsx_wetu_accommodation_images_cron', array( $this, 'process' ), 10, 1 );
-		add_action( 'lsx_wetu_accommodation_images_sync', array( $this, 'cron_callback' ), 10 );
+		add_action( 'lsx_wetu_accommodation_images_sync', array( $this, 'cron_callback' ), 10, 1 );
 	}
 
 	/**
@@ -158,7 +158,23 @@ class Cron {
 	 *
 	 * @return void
 	 */
-	public function cron_callback() {
+	public function cron_callback( $task = '' ) {
+		$has_accommodation = get_option( $task );
+		if ( false !== $has_accommodation && ! empty( $has_accommodation ) ) {
+			$next_time = array_slice( $has_accommodation, 5 );      // returns "c", "d", and "e"
+			$output    = array_slice( $has_accommodation, 0, 4 );   // returns "a", "b", and "c"
+
+			// Run through the current items.
+
+			// Save the values for next time.
+			if ( ! empty( $next_time ) ) {
+				update_option( $task, $next_time );
+			} else {
+				$this->deactivate( $task );
+			}
+		} else {
+			$this->deactivate( $task );
+		}
 	}
 
 	/**
@@ -184,7 +200,7 @@ class Cron {
 		}
 		$items = new \WP_Query( $args );
 		if ( $items->have_posts() ) {
-			add_option( 'lsx_wetu_' . $task . '_sync', $items->posts );
+			update_option( 'lsx_wetu_' . $task . '_sync', $items->posts );
 		}
 	}
 }

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The main plugin class.
+ *
+ * @package   LSX_WETU_Importer
+ * @author    LightSpeed
+ * @license   GPL-2.0+
+ * @link
+ * @copyright 2016 LightSpeed
+ */
+
+namespace lsx\wetu_importer\classes;
+
+/**
+ * The Main plugin class.
+ */
+class Cron {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object|Module_Template
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Initialize the plugin by setting localization, filters, and administration functions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @access private
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object Cron()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+}
+Cron::get_instance();

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -33,6 +33,7 @@ class Cron {
 	 * @access private
 	 */
 	public function __construct() {
+		add_action( 'lsx_wetu_importer_settings_before', array( $this, 'watch_for_trigger' ), 200 );
 	}
 
 	/**
@@ -49,5 +50,71 @@ class Cron {
 		}
 		return self::$instance;
 	}
+
+	/**
+	 * Watches for changes in the button triggers.
+	 *
+	 * @return void
+	 */
+	public function watch_for_trigger() {
+
+		if ( isset( $_GET['page'] ) && 'lsx-wetu-importer' === $_GET['page'] && isset( $_GET['tab'] ) && 'settings' === $_GET['tab'] ) {
+			$options = lsx_wetu_get_options();
+
+			// Check what state the option is in.
+			$accommodation_cron = 'deactivate';
+			if ( isset( $options['accommodation_images_cron'] ) && '' !== $options['accommodation_images_cron'] ) {
+				$accommodation_cron = 'activate';
+			}
+
+			// Check what state the cron is in.
+			$schedule = false;
+			if ( wp_next_scheduled( 'lsx_wetu_accommodation_images_cron' ) ) {
+				$schedule = true;
+			}
+
+			// If activate and its not running.
+			if ( false === $schedule && 'activate' === $accommodation_cron ) {
+				$this->schedule();
+			} elseif ( true === $schedule && 'deactivate' === $accommodation_cron ) {
+				$this->deactivate();
+			}
+		}
+	}
+
+	/**
+	 * Remove our cron from the shedule.
+	 *
+	 * @return void
+	 */
+	public function deactivate( $task = 'lsx_wetu_accommodation_images_cron' ) {
+		wp_clear_scheduled_hook( $task );
+	}
+
+	/**
+	 * This function will schedule the cron event.
+	 *
+	 * @param string $task
+	 * @return void
+	 */
+	public function schedule( $task = 'lsx_wetu_accommodation_images_cron' ) {
+		add_action( $task, array( $this, 'process' ) );
+		add_action( $task, 'lsx_wetu_accommodation_images_callback' );
+		add_action( 'lsx_wetu_accommodation_images_cron', 'lsx_wetu_accommodation_images_callback' );
+		wp_schedule_event( time(), 'daily', 'lsx_wetu_accommodation_images_cron' );
+	}
+
+	/**
+	 * This is the function that will be triggered by the cron event.
+	 *
+	 * @return void
+	 */
+	public function process() {
+		// do your stuff.
+	}
 }
 Cron::get_instance();
+
+function lsx_wetu_accommodation_images_callback() {
+
+}

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -179,16 +179,9 @@ class Cron {
 					if ( isset( $adata[0] ) && isset( $adata[0]['last_modified'] ) && '' !== $adata[0]['last_modified'] ) {
 						$modified_time = strtotime( $adata[0]['last_modified'] );
 						if ( $modified_time > $last_date ) {
-							/*print_r('<pre>');
-							print_r( $wetu_id );
-							print_r('</pre>');
-							print_r('<pre>');
-							print_r( $last_date );
-							print_r('</pre>');
-							print_r('<pre>');
-							print_r( $modified_time );
-							print_r('</pre>');
-							die();*/
+							$accommodation_importer = new \LSX_WETU_Importer_Accommodation();
+							$accommodation_importer->create_main_gallery( $adata, $accommodation );
+							update_post_meta( $accommodation, 'lsx_wetu_modified_date', $modified_time, $last_date );
 						}
 					}
 				}

--- a/classes/class-lsx-wetu-importer-settings.php
+++ b/classes/class-lsx-wetu-importer-settings.php
@@ -62,6 +62,8 @@ class LSX_WETU_Importer_Settings {
 			'height'                             => '600',
 			'scaling'                            => 'h',
 			'enable_tour_ref_column'             => '',
+			'cron_schedule'                      => 'daily',
+			'accommodation_images_cron'          => '',
 		);
 		$this->fields   = array_keys( $this->defaults );
 		add_action( 'admin_init', array( $this, 'save_options' ) );
@@ -93,6 +95,7 @@ class LSX_WETU_Importer_Settings {
 		<div class="wrap">
 			<form method="post" class="">
 				<?php wp_nonce_field( 'lsx_wetu_importer_save', 'lsx_wetu_importer_save_options' ); ?>
+				<?php do_action( 'lsx_wetu_importer_settings_before' ); ?>
 				<h1><?php esc_html_e( 'General', 'lsx-wetu-importer' ); ?></h1>
 				<table class="form-table">
 					<tbody>
@@ -444,6 +447,61 @@ class LSX_WETU_Importer_Settings {
 						</tr>
 					</tbody>
 				</table>
+
+				<h1><?php esc_html_e( 'Sync', 'lsx-wetu-importer' ); ?></h1>
+
+				<table class="form-table">
+					<tbody>
+						<tr class="form-field -wrap">
+							<th scope="row">
+								<label for="cron_schedule"><?php esc_html_e( 'Schedule', 'lsx-wetu-importer' ); ?></label>
+							</th>
+							<td>
+								<select name="cron_schedule" id="cron_schedule"	class="widefat layout">
+									<?php
+									if ( isset( $options['cron_schedule'] ) && '' !== $options['cron_schedule'] ) {
+										$schedule = $options['cron_schedule'];
+									} else {
+										$schedule = 'daily';
+									}
+									$timeslots = array(
+										'daily'      => __( 'Daily', 'lsx-wetu-importer' ),
+										'weekly-mon' => __( 'Weekly (Monday)', 'lsx-wetu-importer' ),
+										'weekly-tue' => __( 'Weekly (Tuesday)', 'lsx-wetu-importer' ),
+										'weekly-wed' => __( 'Weekly (Wednesday)', 'lsx-wetu-importer' ),
+										'weekly-thu' => __( 'Weekly (Thursday)', 'lsx-wetu-importer' ),
+										'weekly-fri' => __( 'Weekly (Friday)', 'lsx-wetu-importer' ),
+										'weekly-sat' => __( 'Weekly (Saturday)', 'lsx-wetu-importer' ),
+										'weekly-sun' => __( 'Weekly (Sunday)', 'lsx-wetu-importer' ),
+									);
+									foreach ( $timeslots as $key => $name ) {
+										$selected = ( $schedule == $key ) ? ' selected="selected"' : '';
+										?>
+										<option value="<?php echo wp_kses_post( $key ); ?>" id="<?php echo wp_kses_post( $key ); ?>" <?php echo wp_kses_post( $selected ); ?>><?php echo wp_kses_post( $name ); ?></option>
+										<?php
+									}
+									?>
+								</select>
+							</td>
+						</tr>
+						<tr class="form-field -wrap">
+							<th scope="row">
+								<label for="accommodation_images_cron"><?php esc_html_e( 'Accommodation Images', 'lsx-wetu-importer' ); ?></label>
+							</th>
+							<td>
+								<input type="checkbox"
+								<?php
+								if ( isset( $options['accommodation_images_cron'] ) && '' !== $options['accommodation_images_cron'] ) {
+									echo esc_attr( 'checked="checked"' );
+								}
+								?>
+								name="accommodation_images_cron" />
+								<p><?php esc_html_e( 'Update the accommodation images accodring to the schedule above.', 'lsx-wetu-importer' ); ?></p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+
 				<p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_html_e( 'Save Changes', 'lsx-wetu-importer' ); ?>"></p>
 			</form>
 		</div>

--- a/classes/class-lsx-wetu-importer.php
+++ b/classes/class-lsx-wetu-importer.php
@@ -216,6 +216,8 @@ class LSX_WETU_Importer {
 		require_once LSX_WETU_IMPORTER_PATH . 'classes/class-lsx-wetu-importer-destination.php';
 		require_once LSX_WETU_IMPORTER_PATH . 'classes/class-lsx-wetu-importer-tours.php';
 		require_once LSX_WETU_IMPORTER_PATH . 'classes/class-lsx-wetu-importer-settings.php';
+		require_once LSX_WETU_IMPORTER_PATH . 'classes/class-cron.php';
+
 		if ( isset( $this->options ) && isset( $this->options['enable_tour_ref_column'] ) && '' !== $this->options['enable_tour_ref_column'] ) {
 			require_once LSX_WETU_IMPORTER_PATH . 'classes/class-lsx-wetu-importer-post-columns.php';
 			$this->post_columns = LSX_WETU_Importer_Post_Columns::get_instance();
@@ -230,11 +232,7 @@ class LSX_WETU_Importer {
 			add_action( 'wp_ajax_lsx_import_items', array( $this, 'process_ajax_import' ) );
 			add_action( 'wp_ajax_nopriv_lsx_import_items', array( $this, 'process_ajax_import' ) );
 		}
-
-		//delete_transient( 'lsx_ti_tours' );
 	}
-
-	// ACTIVATION FUNCTIONS.
 
 	/**
 	 * Load the plugin text domain for translation.


### PR DESCRIPTION
### Requirements
We would like the accommodation posts to update their images,  when changes have been detected in WETU.

### Description of the Change
We have added in a cron function which runs at a specified time,  it registers another cron function which runs every 5 min till the list off accommodation has been checked.  After that is disabled it self.

### Benefits
Accommodation galleries will always have the same images that the supplies have set.

### Possible Drawbacks
The cron function running every 5 min could slow the site down for a bit while it runs.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry
- Added in a cron automation function for the accommodation images.